### PR TITLE
add HEAD method default for GET method

### DIFF
--- a/hitch.go
+++ b/hitch.go
@@ -58,6 +58,7 @@ func (h *Hitch) HandleFunc(method, path string, handler func(http.ResponseWriter
 // Get registers a GET handler for the given path.
 func (h *Hitch) Get(path string, handler http.Handler, middleware ...func(http.Handler) http.Handler) {
 	h.Handle("GET", path, handler, middleware...)
+	h.Handle("HEAD", path, handler, middleware...)
 }
 
 // Put registers a PUT handler for the given path.


### PR DESCRIPTION
It is sometimes annoying that when i use `curl -I`, same as `curl --head` to a GET page but returns 404,
so I added HEAD method to GET.

before:
(curl 127.0.0.1:8000/abi is OK)

```
$ curl -I 127.0.0.1:8000/abi
HTTP/1.1 404 Not Found
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
X-Powered-By: X-server-404
Date: Sun, 13 Sep 2015 17:25:40 GMT
Content-Length: 19
```

after:

```
$ curl --head 127.0.0.1:8000/abi
HTTP/1.1 307 Temporary Redirect
Location: /abi/
X-Powered-By: X-server
Date: Sun, 13 Sep 2015 17:32:39 GMT
Content-Type: text/plain; charset=utf-8
```
