### PR TITLE
switch to standard context from nbio/httpcontext

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `go get github.com/nbio/hitch`
 
-Hitch ties [httprouter](https://github.com/julienschmidt/httprouter), [httpcontext](https://github.com/nbio/httpcontext), and middleware up in a bow. [Simple example](https://gist.github.com/ydnar/666f0bf5945d76592616).
+Hitch ties [httprouter](https://github.com/julienschmidt/httprouter), context, and middleware up in a bow. [Simple example](https://gist.github.com/ydnar/666f0bf5945d76592616).
 
 ## Middleware
 

--- a/hitch.go
+++ b/hitch.go
@@ -1,13 +1,13 @@
 package hitch
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/nbio/httpcontext"
 )
 
-// Hitch ties httprouter, httpcontext, and middleware up in a bow.
+// Hitch ties httprouter, context, and middleware up in a bow.
 type Hitch struct {
 	Router     *httprouter.Router
 	middleware []func(http.Handler) http.Handler
@@ -100,17 +100,14 @@ const paramsKey key = 1
 
 func wrap(handler http.Handler) httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
-		httpcontext.Set(req, paramsKey, params)
+		ctx := context.WithValue(req.Context(), paramsKey, params)
+		*req = *req.WithContext(ctx)
 		handler.ServeHTTP(w, req)
 	}
 }
 
 // Params returns the httprouter.Params for req.
 func Params(req *http.Request) httprouter.Params {
-	if value, ok := httpcontext.GetOk(req, paramsKey); ok {
-		if params, ok := value.(httprouter.Params); ok {
-			return params
-		}
-	}
-	return httprouter.Params{}
+	// zero value (httprouter.Params{}) is returned when type assertion failed
+	return req.Context().Value(paramsKey).(httprouter.Params)
 }


### PR DESCRIPTION
Now the standard context package is there, so how about using it to embed the Param?