### PR TITLE
Use httprouter 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 `go get github.com/nbio/hitch`
 
-Hitch ties [httprouter](https://github.com/julienschmidt/httprouter), context, and middleware up in a bow. [Simple example](https://gist.github.com/ydnar/666f0bf5945d76592616).
+Hitch ties [httprouter](https://github.com/julienschmidt/httprouter), [context](https://golang.org/pkg/context/), and [middleware](https://medium.com/@matryer/writing-middleware-in-golang-and-how-go-makes-it-so-much-fun-4375c1246e81) up in a bow.
+
+- [Simple example](https://gist.github.com/ydnar/666f0bf5945d76592616)
+- [Documentation](https://pkg.go.dev/github.com/nbio/hitch?tab=doc)
 
 ## Middleware
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/nbio/hitch
 
 go 1.14
 
-require github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21
+require github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21 h1:F/iKcka0K2LgnKy/fgSBf235AETtm1n1TvBzqu40LE0=
 github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/hitch.go
+++ b/hitch.go
@@ -6,10 +6,13 @@ import (
 	"github.com/julienschmidt/httprouter"
 )
 
+// Middleware wraps an http.Handler, returning a new http.Handler.
+type Middleware func(http.Handler) http.Handler
+
 // Hitch ties httprouter, context, and middleware up in a bow.
 type Hitch struct {
 	Router     *httprouter.Router
-	middleware []func(http.Handler) http.Handler
+	middleware []Middleware
 }
 
 // New initializes a new Hitch.
@@ -22,7 +25,7 @@ func New() *Hitch {
 }
 
 // Use installs one or more middleware in the Hitch request cycle.
-func (h *Hitch) Use(middleware ...func(http.Handler) http.Handler) {
+func (h *Hitch) Use(middleware ...Middleware) {
 	h.middleware = append(h.middleware, middleware...)
 }
 
@@ -42,7 +45,7 @@ func (h *Hitch) Next(handler http.Handler) {
 }
 
 // Handle registers a handler for the given method and path.
-func (h *Hitch) Handle(method, path string, handler http.Handler, middleware ...func(http.Handler) http.Handler) {
+func (h *Hitch) Handle(method, path string, handler http.Handler, middleware ...Middleware) {
 	for i := len(middleware) - 1; i >= 0; i-- {
 		handler = middleware[i](handler)
 	}
@@ -50,37 +53,37 @@ func (h *Hitch) Handle(method, path string, handler http.Handler, middleware ...
 }
 
 // HandleFunc registers a func handler for the given method and path.
-func (h *Hitch) HandleFunc(method, path string, handler func(http.ResponseWriter, *http.Request), middleware ...func(http.Handler) http.Handler) {
+func (h *Hitch) HandleFunc(method, path string, handler func(http.ResponseWriter, *http.Request), middleware ...Middleware) {
 	h.Handle(method, path, http.HandlerFunc(handler), middleware...)
 }
 
 // Get registers a GET handler for the given path.
-func (h *Hitch) Get(path string, handler http.Handler, middleware ...func(http.Handler) http.Handler) {
+func (h *Hitch) Get(path string, handler http.Handler, middleware ...Middleware) {
 	h.Handle("GET", path, handler, middleware...)
 }
 
 // Put registers a PUT handler for the given path.
-func (h *Hitch) Put(path string, handler http.Handler, middleware ...func(http.Handler) http.Handler) {
+func (h *Hitch) Put(path string, handler http.Handler, middleware ...Middleware) {
 	h.Handle("PUT", path, handler, middleware...)
 }
 
 // Post registers a POST handler for the given path.
-func (h *Hitch) Post(path string, handler http.Handler, middleware ...func(http.Handler) http.Handler) {
+func (h *Hitch) Post(path string, handler http.Handler, middleware ...Middleware) {
 	h.Handle("POST", path, handler, middleware...)
 }
 
 // Patch registers a PATCH handler for the given path.
-func (h *Hitch) Patch(path string, handler http.Handler, middleware ...func(http.Handler) http.Handler) {
+func (h *Hitch) Patch(path string, handler http.Handler, middleware ...Middleware) {
 	h.Handle("PATCH", path, handler, middleware...)
 }
 
 // Delete registers a DELETE handler for the given path.
-func (h *Hitch) Delete(path string, handler http.Handler, middleware ...func(http.Handler) http.Handler) {
+func (h *Hitch) Delete(path string, handler http.Handler, middleware ...Middleware) {
 	h.Handle("DELETE", path, handler, middleware...)
 }
 
 // Options registers a OPTIONS handler for the given path.
-func (h *Hitch) Options(path string, handler http.Handler, middleware ...func(http.Handler) http.Handler) {
+func (h *Hitch) Options(path string, handler http.Handler, middleware ...Middleware) {
 	h.Handle("OPTIONS", path, handler, middleware...)
 }
 


### PR DESCRIPTION
- Eliminate wrapping and use httprouter 1.3 native `http.Handler` interface.
- Params just makes a passthrough call to `httprouter.ParamsFromContext`.